### PR TITLE
fix: update alex CI to not filter files on non PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
       - name: Lint
         uses: reviewdog/action-alex@v1
         with:
+          filter_mode: ${{ github.event_name == 'pull_request' && 'added' || 'nofilter' }}
           level: info
           reporter: ${{ github.event_name == 'pull_request' && 'github-pr-review' || 'local' }}
 


### PR DESCRIPTION
Fixes Alex trying to filter files by added files in non PR CI runes. See: https://github.com/btkostner/jumar/actions/runs/4506028011/jobs/7932389823