### PR TITLE
fix: update test CI for better caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 ---
 
+env:
+  MIX_ENV: test
+
 jobs:
   Docs:
     runs-on: ubuntu-latest
@@ -301,14 +304,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Start Docker Compose
-        uses: ./.github/actions/start-docker-compose
-
       - name: Setup Elixir
         uses: ./.github/actions/setup-elixir
 
       - name: Compile
         run: mix compile --all-warnings --warnings-as-errors
+
+      - name: Start Docker Compose
+        uses: ./.github/actions/start-docker-compose
 
       - name: Test
         run: mix test --all-warnings --cover --warnings-as-errors

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,5 @@
 ---
 
-env:
-  MIX_ENV: test
-
 jobs:
   Docs:
     runs-on: ubuntu-latest
@@ -298,6 +295,9 @@ jobs:
           sarif_file: results.sarif
 
   Test:
+    env:
+      MIX_ENV: test
+
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Taking a look at CI runs like [this one](https://github.com/btkostner/jumar/actions/runs/4506053365/jobs/7932439436), it seems the Test CI is not using caching efficiently. 