### PR TITLE
fix: replace docker-compose with docker compose

### DIFF
--- a/.github/actions/start-docker-compose/action.yml
+++ b/.github/actions/start-docker-compose/action.yml
@@ -4,7 +4,7 @@ branding:
   icon: anchor
 
 description: >-
-  Starts the docker-compose services.
+  Starts the docker compose services.
 
 name: Start Docker Compose
 
@@ -17,7 +17,7 @@ runs:
         COMPOSE_DOCKER_CLI_BUILD: "1"
         DOCKER_BUILDKIT: "1"
       name: Start Containers
-      run: docker-compose up --detach
+      run: docker compose up --detach
       shell: bash
 
   using: composite

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 ---
-
 services:
   cockroach:
     build:
@@ -10,8 +9,6 @@ services:
       - 8080:8080
     volumes:
       - cockroach:/cockroach/cockroach-data
-
-version: "3"
 
 volumes:
   cockroach:

--- a/docs/development.md
+++ b/docs/development.md
@@ -3,9 +3,9 @@
 To get started with development on Jumar, you'll need two things:
 
 - A working `elixir` install where you can run `mix deps.get` successfully
-- A working `docker` and `docker-compose` setup
+- A working `docker` and `docker compose` setup
 
-Once you have those two things, you can start all of the Jumar dependencies via `docker-compose up`. This will start the database (Cockroach DB), the message broker (RabbitMQ), the web browsers used for automated tests, as well as a couple of tools for observability. All of these should be setup and work out of the box without any further setup.
+Once you have those two things, you can start all of the Jumar dependencies via `docker compose up`. This will start the database (Cockroach DB), the message broker (RabbitMQ), the web browsers used for automated tests, as well as a couple of tools for observability. All of these should be setup and work out of the box without any further setup.
 
 After the dependencies are up, you can interact with the Jumar Elixir project like most others. First run `mix setup` to download the dependencies, run database migrations, and install tools needed for the asset pipeline. Finally run `mix phx.server` to start up the web server.
 


### PR DESCRIPTION
`docker-compose` is being replaced with `docker compose`. It's newer and fixes issues with CI runners not having `docker-compose` installed.